### PR TITLE
Automatically grab corresponding type declarations for @npm imports

### DIFF
--- a/gazelle/js/resolve.go
+++ b/gazelle/js/resolve.go
@@ -183,6 +183,12 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 				name += "/" + s[1]
 			}
 			depSet["@npm//"+name] = true
+
+			// does it have a corresponding @types/[...] declaration?
+			if lang.isNpmDependency("@types/" + name) {
+				depSet["@npm//@types/"+name] = true
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
Automatically grab corresponding type declarations for @npm imports

This is done by assuming that the type declarations package name matches the regular package name.