### PR TITLE
Automatic calculation of shard_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,4 +232,12 @@ The following directives are recognized by this plugin:
     <td colspan="2"><p dir="auto">Provide a default value for the <code>size</code> attribute of generated <code>jest_test</code> rules</p></td>
   </tr>
 
+  <tr>
+    <td><code># gazelle:js_jest_test_per_shard</code></td>
+    <td><code>none</code></td>
+  </tr>
+  <tr>
+    <td colspan="2"><p dir="auto">Provide a ratio of number of counted tests for each increment of the <code>shard_count</code> attribute of generated <code>jest_test</code> rules</p></td>
+  </tr>
+
 </tbody>

--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -76,7 +76,7 @@ type JsConfig struct {
 	Verbose            bool
 	DefaultNpmLabel    string
 	JestConfig         string
-	JestShards         int
+	JestTestsPerShard  int
 	JestSize           string
 }
 
@@ -110,7 +110,7 @@ func NewJsConfig() *JsConfig {
 		Quiet:             false,
 		Verbose:           false,
 		DefaultNpmLabel:   "//:node_modules/",
-		JestShards:        -1,
+		JestTestsPerShard: -1,
 		JestConfig:        "",
 	}
 }
@@ -163,7 +163,7 @@ func (parent *JsConfig) NewChild() *JsConfig {
 	child.CollectAllRoot = parent.CollectAllRoot
 	child.CollectAllSources = parent.CollectAllSources // Copy reference, reinitialized on change to CollectAll
 
-	child.JestShards = parent.JestShards
+	child.JestTestsPerShard = parent.JestTestsPerShard
 	child.JestSize = parent.JestSize
 	child.JestConfig = parent.JestConfig
 
@@ -224,7 +224,7 @@ func (*JS) KnownDirectives() []string {
 		"js_collect_all_assets",
 		"js_aggregate_all_assets",
 		"js_collect_all",
-		"js_jest_shard_count",
+		"js_jest_test_per_shard",
 		"js_jest_size",
 		"js_jest_config",
 		"js_web_asset",
@@ -391,8 +391,8 @@ func (*JS) Configure(c *config.Config, rel string, f *rule.File) {
 			case "js_jest_config":
 				jsConfig.JestConfig = labels.ParseRelative(directive.Value, f.Pkg).Format()
 
-			case "js_jest_shard_count":
-				jsConfig.JestShards = readIntDirective(directive)
+			case "js_jest_test_per_shard":
+				jsConfig.JestTestsPerShard = readIntDirective(directive)
 
 			case "js_jest_size":
 				jsConfig.JestSize = directive.Value

--- a/gazelle/parse_test.go
+++ b/gazelle/parse_test.go
@@ -141,7 +141,7 @@ if (process.ENV.SHOULD_IMPORT) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			imports, err := ParseJS([]byte(tc.js))
+			imports, _, err := ParseJS([]byte(tc.js))
 			if err != nil {
 				t.Error(err)
 				t.FailNow()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -46,6 +46,7 @@ go_binary(
     for t in [
         "collect_all",
         "collect_all_nested",
+        "collect_all_test_shards",
         "collect_asset_modules",
         "collect_asset_singletons",
         "default_npm_label",

--- a/tests/collect_all/my_module/BUILD.in
+++ b/tests/collect_all/my_module/BUILD.in
@@ -1,3 +1,2 @@
 # gazelle:js_collect_all
-# gazelle:js_jest_shard_count 2
 # gazelle:js_jest_size large

--- a/tests/collect_all_nested/my_module/BUILD.in
+++ b/tests/collect_all_nested/my_module/BUILD.in
@@ -1,3 +1,2 @@
 # gazelle:js_collect_all
-# gazelle:js_jest_shard_count 2
 # gazelle:js_jest_size large

--- a/tests/collect_all_nested/my_module/BUILD.out
+++ b/tests/collect_all_nested/my_module/BUILD.out
@@ -2,7 +2,6 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@rules_jest//jest:defs.bzl", "jest_test")
 
 # gazelle:js_collect_all
-# gazelle:js_jest_shard_count 2
 # gazelle:js_jest_size large
 
 jest_test(
@@ -14,7 +13,6 @@ jest_test(
     ],
     config = "//:jest.config",
     data = ["//:package_json"],
-    shard_count = 2,
 )
 
 ts_project(

--- a/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.in
+++ b/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.in
@@ -1,3 +1,2 @@
 # gazelle:js_collect_all
-# gazelle:js_jest_shard_count 2
 # gazelle:js_jest_size large

--- a/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.out
+++ b/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.out
@@ -2,7 +2,6 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@rules_jest//jest:defs.bzl", "jest_test")
 
 # gazelle:js_collect_all
-# gazelle:js_jest_shard_count 2
 # gazelle:js_jest_size large
 
 jest_test(
@@ -14,7 +13,6 @@ jest_test(
     ],
     config = "//:jest.config",
     data = ["//:package_json"],
-    shard_count = 2,
 )
 
 ts_project(

--- a/tests/collect_all_test_shards/BUILD.in
+++ b/tests/collect_all_test_shards/BUILD.in
@@ -1,0 +1,3 @@
+# gazelle:js_root
+# gazelle:js_jest_config :jest.config
+# gazelle:js_quiet

--- a/tests/collect_all_test_shards/BUILD.out
+++ b/tests/collect_all_test_shards/BUILD.out
@@ -1,0 +1,22 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_root
+# gazelle:js_jest_config :jest.config
+# gazelle:js_quiet
+
+ts_project(
+    name = "index",
+    srcs = ["index.ts"],
+    deps = ["//my_module"],
+)
+
+ts_project(
+    name = "some_other_file",
+    srcs = ["some_other_file.ts"],
+)
+
+js_library(
+    name = "jest.config",
+    srcs = ["jest.config.js"],
+)

--- a/tests/collect_all_test_shards/WORKSPACE
+++ b/tests/collect_all_test_shards/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "simple_module")

--- a/tests/collect_all_test_shards/index.ts
+++ b/tests/collect_all_test_shards/index.ts
@@ -1,0 +1,3 @@
+import { some_var } from "./my_module/nested_module"
+
+var _ = some_var

--- a/tests/collect_all_test_shards/my_module/BUILD.in
+++ b/tests/collect_all_test_shards/my_module/BUILD.in
@@ -1,0 +1,3 @@
+# gazelle:js_collect_all
+# gazelle:js_jest_size small
+# gazelle:js_jest_test_per_shard 2

--- a/tests/collect_all_test_shards/my_module/BUILD.out
+++ b/tests/collect_all_test_shards/my_module/BUILD.out
@@ -2,17 +2,19 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@rules_jest//jest:defs.bzl", "jest_test")
 
 # gazelle:js_collect_all
-# gazelle:js_jest_size large
+# gazelle:js_jest_size small
+# gazelle:js_jest_test_per_shard 2
 
 jest_test(
     name = "my_module_test",
-    size = "large",
+    size = "small",
     srcs = [
         "nested_module/a.test.ts",
         "nested_module/b.test.ts",
     ],
     config = "//:jest.config",
     data = ["//:package_json"],
+    shard_count = 9,
 )
 
 ts_project(

--- a/tests/collect_all_test_shards/my_module/index.ts
+++ b/tests/collect_all_test_shards/my_module/index.ts
@@ -1,0 +1,1 @@
+export { some_private_var as some_var } from "./module_file"

--- a/tests/collect_all_test_shards/my_module/module_file.ts
+++ b/tests/collect_all_test_shards/my_module/module_file.ts
@@ -1,0 +1,1 @@
+export var some_private_var = "Hello"

--- a/tests/collect_all_test_shards/my_module/nested_module/a.test.ts
+++ b/tests/collect_all_test_shards/my_module/nested_module/a.test.ts
@@ -1,0 +1,11 @@
+// Empty file
+
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});

--- a/tests/collect_all_test_shards/my_module/nested_module/b.test.ts
+++ b/tests/collect_all_test_shards/my_module/nested_module/b.test.ts
@@ -1,0 +1,13 @@
+// Empty file
+
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {});
+it("should run a test", () => {
+    expect(1).toBe(1);
+});

--- a/tests/collect_all_test_shards/my_module/nested_module/index.ts
+++ b/tests/collect_all_test_shards/my_module/nested_module/index.ts
@@ -1,0 +1,1 @@
+export { some_private_var as some_var } from "./module_file"

--- a/tests/collect_all_test_shards/my_module/nested_module/module_file.ts
+++ b/tests/collect_all_test_shards/my_module/nested_module/module_file.ts
@@ -1,0 +1,1 @@
+export var some_private_var = "Hello"

--- a/tests/collect_all_test_shards/my_module/some_other_file.ts
+++ b/tests/collect_all_test_shards/my_module/some_other_file.ts
@@ -1,0 +1,1 @@
+export var baz = "qux"

--- a/tests/collect_all_test_shards/some_other_file.ts
+++ b/tests/collect_all_test_shards/some_other_file.ts
@@ -1,0 +1,1 @@
+export var foo = "bar"


### PR DESCRIPTION
Use #gazelle:js_jest_test_per_shard to specify a ratio of shards per number of jest tests.