### PR TITLE
Simplify jest_test rules

### DIFF
--- a/examples/nextjs/apps/alpha/pages/BUILD.bazel
+++ b/examples/nextjs/apps/alpha/pages/BUILD.bazel
@@ -33,15 +33,6 @@ jest_test(
     srcs = ["index.test.tsx"],
     config = "//apps/alpha:jest.config",
     data = [
-        "//:node_modules/@testing-library/jest-dom",
-        "//:node_modules/@testing-library/react",
-        "//:node_modules/jest-environment-jsdom",
-        "//:node_modules/jest-transform-stub",
-        "//:node_modules/react",
-        "//apps/alpha:package_json",
-    ],
-    visibility = ["//apps/alpha:__subpackages__"],
-    deps = [
         ":pages",
         "//:node_modules/@testing-library/jest-dom",
         "//:node_modules/@testing-library/react",
@@ -49,5 +40,7 @@ jest_test(
         "//:node_modules/jest-environment-jsdom",
         "//:node_modules/jest-transform-stub",
         "//:node_modules/react",
+        "//apps/alpha:package_json",
     ],
+    visibility = ["//apps/alpha:__subpackages__"],
 )

--- a/examples/nextjs/apps/alpha/pages/BUILD.bazel
+++ b/examples/nextjs/apps/alpha/pages/BUILD.bazel
@@ -43,4 +43,13 @@ jest_test(
         "//apps/alpha:package_json",
     ],
     visibility = ["//apps/alpha:__subpackages__"],
+    deps = [
+        ":pages",
+        "//:node_modules/@testing-library/jest-dom",
+        "//:node_modules/@testing-library/react",
+        "//:node_modules/@types/jest",
+        "//:node_modules/jest-environment-jsdom",
+        "//:node_modules/jest-transform-stub",
+        "//:node_modules/react",
+    ],
 )

--- a/examples/nextjs/bazel/jest_test.bzl
+++ b/examples/nextjs/bazel/jest_test.bzl
@@ -1,11 +1,22 @@
 load("@aspect_rules_jest//jest:defs.bzl", _jest_test = "jest_test")
+load("//bazel:ts_project.bzl", "ts_project")
 
-def jest_test(name = "", srcs = [], data=[], **kwargs):
+def jest_test(name = "", srcs = [], deps=[], data=[], **kwargs):
     """Provides defaults for jest_test"""
 
     node_modules = kwargs.pop("node_modules", "//:node_modules")
     tags = kwargs.pop("tags", ["jest"])
 
+    # This ensures that the test is typechecked.
+    ts_project(
+        name = "%s_js" % name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+    # However we run the test with the untranspiled srcs.
+    # This is to ensure that the snapshot filenames match what would
+    # be used when invoking the test without bazel.
     _jest_test(
         name = name,
         data = srcs + data + ["//:tsconfig"],

--- a/examples/nextjs/bazel/jest_test.bzl
+++ b/examples/nextjs/bazel/jest_test.bzl
@@ -1,23 +1,14 @@
 load("@aspect_rules_jest//jest:defs.bzl", _jest_test = "jest_test")
-load("//bazel:ts_project.bzl", "ts_project")
 
-def jest_test(name = "", srcs = [], deps=[], data=[], **kwargs):
+def jest_test(name = "", srcs = [], data=[], **kwargs):
     """Provides defaults for jest_test"""
 
     node_modules = kwargs.pop("node_modules", "//:node_modules")
     tags = kwargs.pop("tags", ["jest"])
 
-    ts_project(
-        name = "%s_js" % name,
-        srcs = srcs,
-        deps = deps,
-    )
-
-    data.append(":%s_js" % name)
-
     _jest_test(
         name = name,
-        data = data,
+        data = srcs + data + ["//:tsconfig"],
         node_modules = node_modules,
         tags = tags,
         **kwargs,

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -257,21 +257,20 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 
 	// Add in additional jest dependencies
 	if r.Kind() == getKind(c, "jest_test") {
-		// All deps are dataDeps for jest_test rules
+		// All deps are also data for jest_test rules.
 		for name := range depSet {
 			dataSet[name] = true
 		}
-		// Reset the depSet since we don't need it.
-		depSet = make(map[string]bool)
-
 		for name, npmLabel := range jsConfig.NpmDependencies.DevDependencies {
 			if name == "jest-cli" || name == "jest-junit" {
 				continue
 			}
 			if strings.HasPrefix(name, "@types/jest") {
+				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 			if strings.HasPrefix(name, "jest") {
+				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 		}

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -257,15 +257,21 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 
 	// Add in additional jest dependencies
 	if r.Kind() == getKind(c, "jest_test") {
+		// All deps are dataDeps for jest_test rules
+		for name := range depSet {
+			dataSet[name] = true
+		}
+		// Reset the depSet since we don't need it.
+		depSet = make(map[string]bool)
+
 		for name, npmLabel := range jsConfig.NpmDependencies.DevDependencies {
 			if name == "jest-cli" || name == "jest-junit" {
 				continue
 			}
 			if strings.HasPrefix(name, "@types/jest") {
-				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
+				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 			if strings.HasPrefix(name, "jest") {
-				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 		}


### PR DESCRIPTION
rules_jest can directly consume ts tests and doesn't need a ts project
wrapper.

Avoiding transpiling helps speed up test runs and also means that any
test snapshots maintain the `.ts(x)` extensions instead of using `.js(x)`
extensions.

This simplifies the generated jest_test rules to only emit
data attrs and skips the deps attrs. The example was updated to work
with this new setup.
