### PR TITLE
Add support for snapshot attrs for tests that include snapshots

### DIFF
--- a/examples/nextjs/WORKSPACE
+++ b/examples/nextjs/WORKSPACE
@@ -20,9 +20,9 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_jest",
-    sha256 = "52dc08fd252add240124ef7ccc46df3a505121758dfb96578a3d5f2ebb4c2b40",
-    strip_prefix = "rules_jest-0.18.1",
-    url = "https://github.com/aspect-build/rules_jest/releases/download/v0.18.1/rules_jest-v0.18.1.tar.gz",
+    sha256 = "098186ffc450f2a604843d8ba14217088a0e259ea6a03294af5360a7f1bcd3e8",
+    strip_prefix = "rules_jest-0.19.5",
+    url = "https://github.com/aspect-build/rules_jest/releases/download/v0.19.5/rules_jest-v0.19.5.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/examples/nextjs/apps/alpha/pages/BUILD.bazel
+++ b/examples/nextjs/apps/alpha/pages/BUILD.bazel
@@ -42,6 +42,7 @@ jest_test(
         "//:node_modules/react",
         "//apps/alpha:package_json",
     ],
+    snapshots = ["__snapshots__"],
     visibility = ["//apps/alpha:__subpackages__"],
     deps = [
         ":pages",

--- a/examples/nextjs/apps/alpha/pages/BUILD.bazel
+++ b/examples/nextjs/apps/alpha/pages/BUILD.bazel
@@ -33,15 +33,6 @@ jest_test(
     srcs = ["index.test.tsx"],
     config = "//apps/alpha:jest.config",
     data = [
-        "//:node_modules/@testing-library/jest-dom",
-        "//:node_modules/@testing-library/react",
-        "//:node_modules/jest-environment-jsdom",
-        "//:node_modules/jest-transform-stub",
-        "//:node_modules/react",
-        "//apps/alpha:package_json",
-    ],
-    visibility = ["//apps/alpha:__subpackages__"],
-    deps = [
         ":pages",
         "//:node_modules/@testing-library/jest-dom",
         "//:node_modules/@testing-library/react",
@@ -49,5 +40,7 @@ jest_test(
         "//:node_modules/jest-environment-jsdom",
         "//:node_modules/jest-transform-stub",
         "//:node_modules/react",
+        "//apps/alpha:package_json",
     ],
+    visibility = ["//apps/alpha:__subpackages__"],
 )

--- a/examples/nextjs/apps/alpha/pages/BUILD.bazel
+++ b/examples/nextjs/apps/alpha/pages/BUILD.bazel
@@ -43,4 +43,13 @@ jest_test(
         "//apps/alpha:package_json",
     ],
     visibility = ["//apps/alpha:__subpackages__"],
+    deps = [
+        ":pages",
+        "//:node_modules/@testing-library/jest-dom",
+        "//:node_modules/@testing-library/react",
+        "//:node_modules/@types/jest",
+        "//:node_modules/jest-environment-jsdom",
+        "//:node_modules/jest-transform-stub",
+        "//:node_modules/react",
+    ],
 )

--- a/examples/nextjs/apps/alpha/pages/__snapshots__/index.test.tsx.snap
+++ b/examples/nextjs/apps/alpha/pages/__snapshots__/index.test.tsx.snap
@@ -1,282 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshot works 1`] = `
-{
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div
-        class="container"
-      >
-        <main
-          class="main"
-        >
-          <h1
-            class="title"
-          >
-            Welcome to 
-            <a
-              href="https://nextjs.org"
-            >
-              Next.js!
-            </a>
-          </h1>
-          <p
-            class="description"
-          >
-            Get started by editing
-             
-            <code
-              class="code"
-            >
-              pages/index.tsx
-            </code>
-          </p>
-          <div
-            class="grid"
-          >
-            <p>
-              I am One, not Two! Am I odd? true
-              . Is even? 
-              false
-            </p>
-            <a
-              class="card"
-              href="https://nextjs.org/docs"
-            >
-              <h2>
-                Documentation →
-              </h2>
-              <p>
-                Find in-depth information about Next.js features and API.
-              </p>
-            </a>
-            <a
-              class="card"
-              href="https://nextjs.org/learn"
-            >
-              <h2>
-                Learn →
-              </h2>
-              <p>
-                Learn about Next.js in an interactive course with quizzes!
-              </p>
-            </a>
-            <a
-              class="card"
-              href="https://github.com/vercel/next.js/tree/canary/examples"
-            >
-              <h2>
-                Examples →
-              </h2>
-              <p>
-                Discover and deploy boilerplate example Next.js projects.
-              </p>
-            </a>
-            <a
-              class="card"
-              href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            >
-              <h2>
-                Deploy →
-              </h2>
-              <p>
-                Instantly deploy your Next.js site to a public URL with Vercel.
-              </p>
-            </a>
-          </div>
-        </main>
-        <footer
-          class="footer"
-        >
-          <a
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Powered by
-             
-            <span
-              class="logo"
-            >
-              <img
-                alt="Vercel Logo"
-                data-nimg="1"
-                decoding="async"
-                height="16"
-                loading="lazy"
-                src="/vercel.svg"
-                srcset="/vercel.svg 1x, /vercel.svg 2x"
-                style="color: transparent;"
-                width="72"
-              />
-            </span>
-          </a>
-        </footer>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      class="container"
+<DocumentFragment>
+  <div
+    class="container"
+  >
+    <main
+      class="main"
     >
-      <main
-        class="main"
+      <h1
+        class="title"
       >
-        <h1
-          class="title"
-        >
-          Welcome to 
-          <a
-            href="https://nextjs.org"
-          >
-            Next.js!
-          </a>
-        </h1>
-        <p
-          class="description"
-        >
-          Get started by editing
-           
-          <code
-            class="code"
-          >
-            pages/index.tsx
-          </code>
-        </p>
-        <div
-          class="grid"
-        >
-          <p>
-            I am One, not Two! Am I odd? true
-            . Is even? 
-            false
-          </p>
-          <a
-            class="card"
-            href="https://nextjs.org/docs"
-          >
-            <h2>
-              Documentation →
-            </h2>
-            <p>
-              Find in-depth information about Next.js features and API.
-            </p>
-          </a>
-          <a
-            class="card"
-            href="https://nextjs.org/learn"
-          >
-            <h2>
-              Learn →
-            </h2>
-            <p>
-              Learn about Next.js in an interactive course with quizzes!
-            </p>
-          </a>
-          <a
-            class="card"
-            href="https://github.com/vercel/next.js/tree/canary/examples"
-          >
-            <h2>
-              Examples →
-            </h2>
-            <p>
-              Discover and deploy boilerplate example Next.js projects.
-            </p>
-          </a>
-          <a
-            class="card"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-          >
-            <h2>
-              Deploy →
-            </h2>
-            <p>
-              Instantly deploy your Next.js site to a public URL with Vercel.
-            </p>
-          </a>
-        </div>
-      </main>
-      <footer
-        class="footer"
-      >
+        Welcome to 
         <a
-          href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-          rel="noopener noreferrer"
-          target="_blank"
+          href="https://nextjs.org"
         >
-          Powered by
-           
-          <span
-            class="logo"
-          >
-            <img
-              alt="Vercel Logo"
-              data-nimg="1"
-              decoding="async"
-              height="16"
-              loading="lazy"
-              src="/vercel.svg"
-              srcset="/vercel.svg 1x, /vercel.svg 2x"
-              style="color: transparent;"
-              width="72"
-            />
-          </span>
+          Next.js!
         </a>
-      </footer>
-    </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+      </h1>
+      <p
+        class="description"
+      >
+        Get started by editing 
+        <code
+          class="code"
+        >
+          pages/index.tsx
+        </code>
+      </p>
+      <div
+        class="grid"
+      >
+        <p>
+          I am One, not Two! Am I odd? true. Is even? false
+        </p>
+        <a
+          class="card"
+          href="https://nextjs.org/docs"
+        >
+          <h2>
+            Documentation →
+          </h2>
+          <p>
+            Find in-depth information about Next.js features and API.
+          </p>
+        </a>
+        <a
+          class="card"
+          href="https://nextjs.org/learn"
+        >
+          <h2>
+            Learn →
+          </h2>
+          <p>
+            Learn about Next.js in an interactive course with quizzes!
+          </p>
+        </a>
+        <a
+          class="card"
+          href="https://github.com/vercel/next.js/tree/canary/examples"
+        >
+          <h2>
+            Examples →
+          </h2>
+          <p>
+            Discover and deploy boilerplate example Next.js projects.
+          </p>
+        </a>
+        <a
+          class="card"
+          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+        >
+          <h2>
+            Deploy →
+          </h2>
+          <p>
+            Instantly deploy your Next.js site to a public URL with Vercel.
+          </p>
+        </a>
+      </div>
+    </main>
+    <footer
+      class="footer"
+    >
+      <a
+        href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Powered by 
+        <span
+          class="logo"
+        >
+          <img
+            alt="Vercel Logo"
+            data-nimg="1"
+            decoding="async"
+            height="16"
+            loading="lazy"
+            src="/vercel.svg"
+            srcset="/vercel.svg 1x, /vercel.svg 2x"
+            style="color: transparent;"
+            width="72"
+          />
+        </span>
+      </a>
+    </footer>
+  </div>
+</DocumentFragment>
 `;

--- a/examples/nextjs/apps/alpha/pages/__snapshots__/index.test.tsx.snap
+++ b/examples/nextjs/apps/alpha/pages/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,282 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot works 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="container"
+      >
+        <main
+          class="main"
+        >
+          <h1
+            class="title"
+          >
+            Welcome to 
+            <a
+              href="https://nextjs.org"
+            >
+              Next.js!
+            </a>
+          </h1>
+          <p
+            class="description"
+          >
+            Get started by editing
+             
+            <code
+              class="code"
+            >
+              pages/index.tsx
+            </code>
+          </p>
+          <div
+            class="grid"
+          >
+            <p>
+              I am One, not Two! Am I odd? true
+              . Is even? 
+              false
+            </p>
+            <a
+              class="card"
+              href="https://nextjs.org/docs"
+            >
+              <h2>
+                Documentation →
+              </h2>
+              <p>
+                Find in-depth information about Next.js features and API.
+              </p>
+            </a>
+            <a
+              class="card"
+              href="https://nextjs.org/learn"
+            >
+              <h2>
+                Learn →
+              </h2>
+              <p>
+                Learn about Next.js in an interactive course with quizzes!
+              </p>
+            </a>
+            <a
+              class="card"
+              href="https://github.com/vercel/next.js/tree/canary/examples"
+            >
+              <h2>
+                Examples →
+              </h2>
+              <p>
+                Discover and deploy boilerplate example Next.js projects.
+              </p>
+            </a>
+            <a
+              class="card"
+              href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+            >
+              <h2>
+                Deploy →
+              </h2>
+              <p>
+                Instantly deploy your Next.js site to a public URL with Vercel.
+              </p>
+            </a>
+          </div>
+        </main>
+        <footer
+          class="footer"
+        >
+          <a
+            href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Powered by
+             
+            <span
+              class="logo"
+            >
+              <img
+                alt="Vercel Logo"
+                data-nimg="1"
+                decoding="async"
+                height="16"
+                loading="lazy"
+                src="/vercel.svg"
+                srcset="/vercel.svg 1x, /vercel.svg 2x"
+                style="color: transparent;"
+                width="72"
+              />
+            </span>
+          </a>
+        </footer>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="container"
+    >
+      <main
+        class="main"
+      >
+        <h1
+          class="title"
+        >
+          Welcome to 
+          <a
+            href="https://nextjs.org"
+          >
+            Next.js!
+          </a>
+        </h1>
+        <p
+          class="description"
+        >
+          Get started by editing
+           
+          <code
+            class="code"
+          >
+            pages/index.tsx
+          </code>
+        </p>
+        <div
+          class="grid"
+        >
+          <p>
+            I am One, not Two! Am I odd? true
+            . Is even? 
+            false
+          </p>
+          <a
+            class="card"
+            href="https://nextjs.org/docs"
+          >
+            <h2>
+              Documentation →
+            </h2>
+            <p>
+              Find in-depth information about Next.js features and API.
+            </p>
+          </a>
+          <a
+            class="card"
+            href="https://nextjs.org/learn"
+          >
+            <h2>
+              Learn →
+            </h2>
+            <p>
+              Learn about Next.js in an interactive course with quizzes!
+            </p>
+          </a>
+          <a
+            class="card"
+            href="https://github.com/vercel/next.js/tree/canary/examples"
+          >
+            <h2>
+              Examples →
+            </h2>
+            <p>
+              Discover and deploy boilerplate example Next.js projects.
+            </p>
+          </a>
+          <a
+            class="card"
+            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          >
+            <h2>
+              Deploy →
+            </h2>
+            <p>
+              Instantly deploy your Next.js site to a public URL with Vercel.
+            </p>
+          </a>
+        </div>
+      </main>
+      <footer
+        class="footer"
+      >
+        <a
+          href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Powered by
+           
+          <span
+            class="logo"
+          >
+            <img
+              alt="Vercel Logo"
+              data-nimg="1"
+              decoding="async"
+              height="16"
+              loading="lazy"
+              src="/vercel.svg"
+              srcset="/vercel.svg 1x, /vercel.svg 2x"
+              style="color: transparent;"
+              width="72"
+            />
+          </span>
+        </a>
+      </footer>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/examples/nextjs/apps/alpha/pages/index.test.tsx
+++ b/examples/nextjs/apps/alpha/pages/index.test.tsx
@@ -19,7 +19,7 @@ describe('Home', () => {
 
 describe('snapshot', () => {
   it('works', () => {
-    const constainer = render(<Home />);
-    expect(constainer).toMatchSnapshot();
+    const { asFragment } = render(<Home />);
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/examples/nextjs/apps/alpha/pages/index.test.tsx
+++ b/examples/nextjs/apps/alpha/pages/index.test.tsx
@@ -16,3 +16,10 @@ describe('Home', () => {
     expect(heading).toBeInTheDocument();
   });
 });
+
+describe('snapshot', () => {
+  it('works', () => {
+    const constainer = render(<Home />);
+    expect(constainer).toMatchSnapshot();
+  });
+});

--- a/examples/nextjs/bazel/jest_test.bzl
+++ b/examples/nextjs/bazel/jest_test.bzl
@@ -1,11 +1,22 @@
 load("@aspect_rules_jest//jest:defs.bzl", _jest_test = "jest_test")
+load("//bazel:ts_project.bzl", "ts_project")
 
-def jest_test(name = "", srcs = [], data=[], **kwargs):
+def jest_test(name = "", srcs = [], deps=[], data=[], **kwargs):
     """Provides defaults for jest_test"""
 
     node_modules = kwargs.pop("node_modules", "//:node_modules")
     tags = kwargs.pop("tags", ["jest"])
 
+    # This ensures that the test is typechecked.
+    ts_project(
+        name = "%s_js" % name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+    # However we run the test with the untranspiled srcs.
+    # This is to ensure that the snapshot filenames match what would
+    # be used when invoking the test without bazel.
     _jest_test(
         name = name,
         data = srcs + data + ["//:tsconfig"],

--- a/examples/nextjs/bazel/jest_test.bzl
+++ b/examples/nextjs/bazel/jest_test.bzl
@@ -1,23 +1,14 @@
 load("@aspect_rules_jest//jest:defs.bzl", _jest_test = "jest_test")
-load("//bazel:ts_project.bzl", "ts_project")
 
-def jest_test(name = "", srcs = [], deps=[], data=[], **kwargs):
+def jest_test(name = "", srcs = [], data=[], **kwargs):
     """Provides defaults for jest_test"""
 
     node_modules = kwargs.pop("node_modules", "//:node_modules")
     tags = kwargs.pop("tags", ["jest"])
 
-    ts_project(
-        name = "%s_js" % name,
-        srcs = srcs,
-        deps = deps,
-    )
-
-    data.append(":%s_js" % name)
-
     _jest_test(
         name = name,
-        data = data,
+        data = srcs + data + ["//:tsconfig"],
         node_modules = node_modules,
         tags = tags,
         **kwargs,

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -350,7 +350,7 @@ func (lang *JS) genJestTest(args language.GenerateArgs, jsConfig *JsConfig, jest
 			var collectedSnapshots []string
 			snapshotFile, err := os.Stat(path.Join(args.Dir, "__snapshots__", baseName+".snap"))
 			if err == nil && snapshotFile.Mode().IsRegular() {
-				collectedSnapshots = append(collectedSnapshots, path.Join(args.Dir, "__snapshots__", baseName+".snap"))
+				collectedSnapshots = append(collectedSnapshots, path.Join("__snapshots__", baseName+".snap"))
 			}
 
 			lang.addJestAttributes(args, jsConfig, ruleName, r, jestTestCount, collectedSnapshots)

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -257,21 +257,20 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 
 	// Add in additional jest dependencies
 	if r.Kind() == getKind(c, "jest_test") {
-		// All deps are dataDeps for jest_test rules
+		// All deps are also data for jest_test rules.
 		for name := range depSet {
 			dataSet[name] = true
 		}
-		// Reset the depSet since we don't need it.
-		depSet = make(map[string]bool)
-
 		for name, npmLabel := range jsConfig.NpmDependencies.DevDependencies {
 			if name == "jest-cli" || name == "jest-junit" {
 				continue
 			}
 			if strings.HasPrefix(name, "@types/jest") {
+				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 			if strings.HasPrefix(name, "jest") {
+				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 		}

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -257,15 +257,21 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 
 	// Add in additional jest dependencies
 	if r.Kind() == getKind(c, "jest_test") {
+		// All deps are dataDeps for jest_test rules
+		for name := range depSet {
+			dataSet[name] = true
+		}
+		// Reset the depSet since we don't need it.
+		depSet = make(map[string]bool)
+
 		for name, npmLabel := range jsConfig.NpmDependencies.DevDependencies {
 			if name == "jest-cli" || name == "jest-junit" {
 				continue
 			}
 			if strings.HasPrefix(name, "@types/jest") {
-				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
+				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 			if strings.HasPrefix(name, "jest") {
-				depSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 				dataSet[fmt.Sprintf("%s%s", npmLabel, name)] = true
 			}
 		}


### PR DESCRIPTION
This supports automatically generating the snapshot attrs for tests that have
snapshots.

Note that this depends on #47 to make sure that the snapshot extensions
match what one would get if they invoked jest directly without using
bazel.
