### PR TITLE
Nextjs uses parens to create route groups, this ensures we can support them

### DIFF
--- a/gazelle/parse.go
+++ b/gazelle/parse.go
@@ -64,7 +64,7 @@ const (
 var jsImportPattern = compileJsImportPattern()
 
 func compileJsImportPattern() *regexp.Regexp {
-	stringLiteralPattern := `'(?:[^)\n]+|")*'|"(?:[^)\n]+|')*"`
+	stringLiteralPattern := `'(?:[^\n]+|")*'|"(?:[^\n]+|')*"`
 	importPattern := `^import\s(?:(?:.|\n)+?from )??(?P<import>` + stringLiteralPattern + `)`
 	requirePattern := `^\s*?(?:const .+ = )?require\((?P<require>` + stringLiteralPattern + `)\)`
 	exportPattern := `^export\s(?:(?:.|\n)+?from )??(?P<export>` + stringLiteralPattern + `)`

--- a/gazelle/parse_test.go
+++ b/gazelle/parse_test.go
@@ -56,6 +56,16 @@ func TestParseJS(t *testing.T) {
 import Puppy from '@/components/Puppy';`,
 			want: []string{"@/components/Puppy", "date-fns"},
 		}, {
+			desc: "import dynamic",
+			name: "dynamic.ts",
+			js:   `let lamdba = () => import('./b').do_something("something")`,
+			want: []string{"./b"},
+		}, {
+			desc: "import special chars",
+			name: "page.js",
+			js:   `import BlogPage from "@/app/(auth)/blog/[slug]/page";`,
+			want: []string{"@/app/(auth)/blog/[slug]/page"},
+		}, {
 			desc: "import depth",
 			name: "deep.sass",
 			js:   `import package from "from/internal/package";`,


### PR DESCRIPTION
Updates the import regex to allow paths with parens in it.
Added a test that also tests the dynamic imports where the parens were an issue,
that test also passes.
