### PR TITLE
Fix the builtins lookup

### DIFF
--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -231,22 +231,12 @@ func (lang *JS) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remote
 		}
 
 		// is it a builtin?
-		if strings.HasPrefix(name, "node:") {
+		if _, ok := BUILTINS[name]; ok || strings.HasPrefix(name, "node:") {
+			// add @types/node when using node.js builtin and have @types/nodes installed
 			if jsConfig.LookupTypes && r.Kind() == "ts_project" {
 				typesFound, npmLabel, _ := lang.isNpmDependency("@types/node", jsConfig)
 				if typesFound {
 					depSet[fmt.Sprintf("%s@types/node", npmLabel)] = true
-				}
-			}
-			continue
-		}
-		if _, ok := BUILTINS[name]; ok {
-			// add @types/node when using node.js builtin and have @types/nodes installed
-			if jsConfig.LookupTypes && r.Kind() == "ts_project" {
-				// does it have a corresponding @types/[...] declaration?
-				typesFound, npmLabel, _ := lang.isNpmDependency("@types/"+name, jsConfig)
-				if typesFound {
-					depSet[fmt.Sprintf("%s@types/%s", npmLabel, name)] = true
 				}
 			}
 			continue

--- a/tests/lookup_types/BUILD.out
+++ b/tests/lookup_types/BUILD.out
@@ -30,4 +30,5 @@ ts_project(
 ts_project(
     name = "builtin",
     srcs = ["builtin.ts"],
+    deps = ["//:node_modules/@types/node"],
 )


### PR DESCRIPTION
The builtins lookup was looking for `@types/<name>` to be in the NpmDeps instead
of `@types/node`. This looks like it was an error introduced in a major refactor.

This fixes the bug and also updates the test that seems to be written just to
catch this error.
