### PR TITLE
Fix resolver on packages with @types suffix

### DIFF
--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -413,8 +413,8 @@ func (lang *JS) isNpmDependency(imp string, jsConfig *JsConfig) (bool, string, b
 	}
 
 	// Assume all @ imports are npm dependencies
-	if strings.HasPrefix(imp, "@types") {
-		// Need to ignore @types, since these are checked greedily
+	if strings.HasPrefix(imp, "@types/") {
+		// Need to ignore @types/, since these are checked greedily
 		return false, "", false
 	}
 	if strings.HasPrefix(imp, "@") {


### PR DESCRIPTION
Some npm package names starting with the prefix "@types" but not actual "@types/" packages would cause the resolver to loop endlessly inside `resolve.resolveWalkParents` due to a failed check in `resolve.isNpmDependency`.

I found out about this problem when trying to import any package from "@typescript-eslint/..." in one of my files and then running gazelle.
The problem should arise with any package starting with "@types" such as any "@typescript/..." package.