### PR TITLE
fix go.mod to have a correct module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bazelbuild/rules_python
+module github.com/benchsci/rules_nodejs_gazelle
 
 go 1.21
 


### PR DESCRIPTION
The `rules_python` will conflict if this is imported as a Go module.