### PR TITLE
Fix js_collect_all in barrels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,10 @@ jobs:
 
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
-            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            - uses: actions/checkout@v2
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: Mount bazel caches
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: |
                       "~/.cache/bazel"
@@ -39,10 +39,10 @@ jobs:
 
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
-            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            - uses: actions/checkout@v2
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: Mount bazel caches
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: |
                       "~/.cache/bazel"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Mount bazel caches
               uses: actions/cache@v3
               with:

--- a/examples/nextjs/apps/alpha/pages/index.test.tsx
+++ b/examples/nextjs/apps/alpha/pages/index.test.tsx
@@ -16,10 +16,3 @@ describe('Home', () => {
     expect(heading).toBeInTheDocument();
   });
 });
-
-describe('snapshot', () => {
-  it('works', () => {
-    const { asFragment } = render(<Home />);
-    expect(asFragment()).toMatchSnapshot();
-  });
-});

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -112,7 +112,7 @@ func (lang *JS) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.
 	}
 
 	// modules can be resolved via the directory containing them
-	if isBarrel || jsConfig.CollectAll {
+	if (isBarrel || jsConfig.CollectAll) && r.Kind() != getKind(c, "jest_test") {
 		importSpecs = append(importSpecs, resolve.ImportSpec{
 			Lang: lang.Name(),
 			Imp:  f.Pkg,

--- a/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.out
+++ b/tests/collect_all_nested/my_module/nested_module/double_nested_module/BUILD.out
@@ -10,9 +10,14 @@ jest_test(
     srcs = [
         "a.test.ts",
         "b.test.ts",
+        "index.test.ts",
     ],
     config = "//:jest.config",
-    data = ["//:package_json"],
+    data = [
+        ":double_nested_module",
+        "//:package_json",
+    ],
+    deps = [":double_nested_module"],
 )
 
 ts_project(

--- a/tests/collect_all_nested/my_module/nested_module/double_nested_module/index.test.ts
+++ b/tests/collect_all_nested/my_module/nested_module/double_nested_module/index.test.ts
@@ -1,0 +1,1 @@
+export { some_private_var as some_var } from "./module_file"


### PR DESCRIPTION
Fixes a case where js_collect_all is used in a package with both an index.ts and an index.test.ts file together.