### PR TITLE
fix: prevent GitHub Actions expression injection via tag name in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
             - name: bazel test //...
               run: bazel test //...
             - name: Prepare Release
-              run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+              env:
+                  GITHUB_REF_NAME: ${{ github.ref_name }}
+              run: .github/workflows/workspace_snippet.sh "$GITHUB_REF_NAME" > release_notes.txt
             - name: Release
               uses: benchsci/action-gh-release@v1
               with:


### PR DESCRIPTION
## Summary

Fixes a critical **GitHub Actions expression injection** in the `Release` workflow (`.github/workflows/release.yml`).

The `Prepare Release` step interpolated the tag name directly into a shell command using expression syntax:

```yaml
run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
```

GitHub evaluates `${{ }}` **before** the shell runs, pasting the raw tag name into the command line. Because the `Release` workflow triggers on `v*.*.*` tag pushes and tag names can contain shell metacharacters (`;`, backticks, `&&`, `|`, `$()`), a crafted tag could execute arbitrary commands on the runner — with access to that job's `GITHUB_TOKEN` and any secrets in the environment.

## Fix

Bind the ref name to an environment variable and reference it as a quoted shell variable, so GitHub never substitutes untrusted text into the shell command:

```yaml
- name: Prepare Release
  env:
      GITHUB_REF_NAME: ${{ github.ref_name }}
  run: .github/workflows/workspace_snippet.sh "$GITHUB_REF_NAME" > release_notes.txt
```

This is GitHub's recommended remediation pattern for untrusted input in `run:` steps. The value is now passed to the shell at runtime as inert data; metacharacters are treated literally.

## Test plan

- [ ] Verify the `Release` workflow still produces `release_notes.txt` on a normal tag (e.g. `v1.2.3`).
- [ ] Confirm a tag containing shell metacharacters no longer executes injected commands (treated as literal data).

Made with [Cursor](https://cursor.com)